### PR TITLE
remove continuations

### DIFF
--- a/elimination_fixpoints.v
+++ b/elimination_fixpoints.v
@@ -15,7 +15,6 @@ Require Import SMTCoq.SMTCoq.
 From MetaCoq Require Import All.
 Require Import MetaCoq.Template.All.
 Require Import MetaCoq.Template.Universes.
-Require Import MetaCoq.PCUIC.PCUICEquality.
 Require Import MetaCoq.PCUIC.PCUICSubstitution.
 Require Import MetaCoq.Template.All.
 Require Import utilities.

--- a/elimination_fixpoints.v
+++ b/elimination_fixpoints.v
@@ -15,6 +15,7 @@ Require Import SMTCoq.SMTCoq.
 From MetaCoq Require Import All.
 Require Import MetaCoq.Template.All.
 Require Import MetaCoq.Template.Universes.
+Require Import MetaCoq.PCUIC.PCUICEquality.
 Require Import MetaCoq.PCUIC.PCUICSubstitution.
 Require Import MetaCoq.Template.All.
 Require Import utilities.
@@ -84,8 +85,7 @@ end.
 
 (* replace an anonymous fix by its definition *)
 Ltac eliminate_fix_hyp H := 
-let T := type of H in
-quote_term T ltac:(fun T =>
+let T := type of H in let T := metacoq_get_value (tmQuote T) in
 let p := eval cbv in (under_forall T) in 
 let eq := eval cbv in p.1 in
 let list_quantif := eval cbv in p.2 in
@@ -100,15 +100,15 @@ let def := eval cbv in prod.1.1 in
 let u_no_app := eval cbv in prod.1.2 in 
 let u_no_fix := eval cbv in (replace_tFix_by_def u_no_app def) in
 let eq_no_fix := eval cbv in (create_forall (mkEq A t (tApp u_no_fix args)) list_quantif) in
-run_template_program (tmUnquote eq_no_fix) 
-ltac:(fun z => let H' := fresh in let w := eval hnf in z.(my_projT2) 
+let z := metacoq_get_value (tmUnquote eq_no_fix) in
+let H' := fresh in let w := eval hnf in z.(my_projT2) 
 in assert (H' :w) 
-by (repeat (let x := fresh in intro x ; try (destruct x ; auto))) )).
+by (repeat (let x := fresh in intro x ; try (destruct x ; auto))).
 
 
 Ltac eliminate_fix_ho H := fun k =>
 let T := type of H in
-quote_term T ltac:(fun T =>
+let T := metacoq_get_value (tmQuote T) in
 let p := eval cbv in (under_forall T) in 
 let eq := eval cbv in p.1 in
 let list_quantif := eval cbv in p.2 in
@@ -122,11 +122,11 @@ let args := eval cbv in prod.2 in (* the arguments of u *)
 let def := eval cbv in prod.1.1 in 
 let u_no_app := eval cbv in prod.1.2 in 
 let u_no_fix := eval cbv in (replace_tFix_by_def u_no_app def) in 
-let eq_no_fix := eval cbv in (create_forall (mkEq A t (tApp u_no_fix args)) list_quantif)
-in run_template_program (tmUnquote eq_no_fix) 
-ltac:(fun z => let H' := fresh in let w := eval hnf in z.(my_projT2)
+let eq_no_fix := eval cbv in (create_forall (mkEq A t (tApp u_no_fix args)) list_quantif) in
+let z := metacoq_get_value (tmUnquote eq_no_fix) in
+let H' := fresh in let w := eval hnf in z.(my_projT2)
 in assert (H' :w) 
-by (repeat (let x := fresh in intro x ; try (destruct x ; auto))) ; k H' ; clear H)).
+by (repeat (let x := fresh in intro x ; try (destruct x ; auto))) ; k H' ; clear H.
 
 
 

--- a/elimination_polymorphism.v
+++ b/elimination_polymorphism.v
@@ -62,8 +62,8 @@ let U := type of (H' x) in notHyp U ; specialize (H' x) end in H'
 
 
 (* Reifies a term and calls is_type *)
-Ltac is_type_quote t := let t' := eval hnf in t in
-quote_term t' ltac:(fun T => if_else_ltac idtac fail ltac:(eval compute in (is_type T))).
+Ltac is_type_quote t := let t' := eval hnf in t in let T :=
+metacoq_get_value (tmQuote t') in if_else_ltac idtac fail ltac:(eval compute in (is_type T)).
 
 (* instanciates a polymorphic quantified hypothesis with all suitable subterms in the context *)
 Ltac instanciate_type H := let P := type of H  in let P':= type of P in constr_eq P' Prop ; lazymatch P with


### PR DESCRIPTION
Remove continuations when they are not needed thanks to metacoq_get_value