### PR TITLE
Fix: declare opam deps on metarocq on equations

### DIFF
--- a/rocq-sniper.opam
+++ b/rocq-sniper.opam
@@ -29,6 +29,10 @@ depends: [
   "dune" {>= "3.21"}
   "num"
   "rocq-smtcoq"
+  "rocq-metarocq-common" { (= "1.5.1+9.2") | (= "1.5.1+9.1") }
+  "rocq-metarocq-template" { (= "1.5.1+9.2") | (= "1.5.1+9.1") }
+  "rocq-metarocq-utils" { (= "1.5.1+9.2") | (= "1.5.1+9.1") }
+  "rocq-equations" { (= "1.3.2+9.2") | (= "1.3.1+9.1") }
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
The opam file currently doesn't declare the dependencies on MetaRocq and rocq-equations, and they do not follow transitively from `smtcoq` or `trakt` dependencies.
Since the nix build uses MetaRocq 1.5.1, I've constrained these to use the versions available for 9.1 and 9.2. 