### PR TITLE
instantiate_state: rename the Ltac2 binder `is`, reserved as of Rocq 9.4

### DIFF
--- a/theories/transformations/instantiate_state.v
+++ b/theories/transformations/instantiate_state.v
@@ -103,9 +103,9 @@ Ltac2 contexts_printer c :=
   List.iter (fun (x, y) => printf "term: %t" x ;
   List.iter (fun z => printf "context: %t" z) y) c.
 
-Ltac2 inst_state_printer is :=
-  let hi := is.(hyps_inst) in
-  let ti := is.(types_inst) in
+Ltac2 inst_state_printer ist :=
+  let hi := ist.(hyps_inst) in
+  let ti := ist.(types_inst) in
   List.iter (fun (x, y) => printf "hypothesis: %t" x ;
     List.iter (fun z => printf "context: %t" z) y) hi ;
   printf "types inst:" ;
@@ -115,8 +115,8 @@ Ltac2 inst_state_printer is :=
 
 Ltac2 isr_printer isr :=
   match isr with
-    | ISR is =>
-        inst_state_printer (is.(contents))
+    | ISR ist =>
+        inst_state_printer (ist.(contents))
     | _ => Control.throw Wrong_reference
   end.
 
@@ -462,8 +462,8 @@ Ltac2 is_empty l :=
 
 Ltac2 instantiate_state isr :=
   match isr with
-    | ISR is => 
-        let state := get is in
+    | ISR ist =>
+        let state := get ist in
         let hyp_ctx_l := state.(hyps_inst) in 
         if is_empty hyp_ctx_l then () else
           let ty_ctx_l := state.(types_inst) in 
@@ -514,8 +514,8 @@ Ltac2 compute_init_state () :=
 Ltac2 init_state (isr : refs) :=
 let s := compute_init_state () in 
   match isr with
-    | ISR is =>
-        setref is s
+    | ISR ist =>
+        setref ist s
     | _ => Control.throw Wrong_reference
   end.
 
@@ -527,9 +527,9 @@ Ltac2 new_hyp_concrete_type
   (h : constr) :=
   let tyi := find_context_types (type h) in 
     match isr with
-      | ISR is =>
-          let res := get is in 
-          setref is { hyps_inst := res.(hyps_inst) ; types_inst := List.append (res.(types_inst)) tyi }
+      | ISR ist =>
+          let res := get ist in
+          setref ist { hyps_inst := res.(hyps_inst) ; types_inst := List.append (res.(types_inst)) tyi }
           might_instantiate_type tyi res.(hyps_inst)
       | _ => Control.throw Wrong_reference
     end.  *)


### PR DESCRIPTION
`theories/transformations/instantiate_state.v` no longer parses on the Rocq development branch. `is` has become a reserved keyword and can no longer be used as an Ltac2 binder:

```
File "./theories/transformations/instantiate_state.v", line 106, characters 25-27:
Error: Syntax error: [input_fun] expected after [binder] (in [tac2def_body]).
```

Reduced to two lines: `From Ltac2 Require Import Ltac2. Ltac2 f is := is.` exits 0 at 9.1.1 and at 9.2+rc2, and exits 1 at 9.4+alpha with exactly the error above.

This renames the binder to `ist` at the five places it occurs in that file (four in live code, one inside the commented-out block at the end of the file, renamed so the block stays consistent). It is an alpha-renaming of a local Ltac2 binder; nothing exported changes, and `ist` does not occur anywhere else in the file.

What was measured, on an opam switch running `The Rocq Prover, version 9.4+alpha` (OCaml 4.14.2):

| tree | `dune build theories/` | errors | `.vo` |
|---|---|---|---|
| `main` @ e743fadcd9e6 | exit 1 | 1 (the one above) | 26 |
| same tree + this patch | exit 0 | 0 | 29 |

Backward compatible with released Rocq, on the following evidence: the two-line probe in its fixed form (`Ltac2 f ist := ist.`) exits 0 at 9.1.1, 9.2+rc2 and 9.4+alpha, and a binder rename cannot depend on the prover version. I did not run a full build of the project at 9.1 or 9.2 — the only version I built the whole `theories/` tree on is 9.4+alpha.

## Environment

The switch that produced the table above also carries `rocq-smtcoq` from `smtcoq/smtcoq#rocq-master`, and `rocq-trakt` and `rocq-equations` at `dev`.

Two provenance notes, since not everything on it is pristine upstream:

- The prover is built from `theorem-labs/rocq@7478cd16`, which is `rocq-prover/rocq` master plus 34 commits and minus 17. Its substantive addition is a kernel module-subtyping *performance* fix; it cannot turn a syntax error into a success. The grammar question here does not rest on that build in any case — the two-line probe settles it, and it runs on released 9.1.1 and 9.2+rc2 too.
- `rocq-elpi` is `theorem-labs/coq-elpi#dev+fixes` and `rocq-metarocq-template` is `theorem-labs/metarocq#claude/forward-merge-9.1`; both are diverged from their upstreams. Neither is implicated in the parse failure, but both were in the environment when the `.vo` counts were taken, so I cannot claim those two numbers reproduce exactly against pristine upstream elpi and MetaRocq.

## Open PRs

This repository has none open, so nothing here competes with work already in your queue.

## Deliberately not included

- No packaging changes. The exact pins on `rocq-equations` and `rocq-metarocq-template` in `dune-project` cannot be satisfied on a development switch, where both resolve to version `dev`; that does not affect the build, so this PR leaves them alone. I have a patch adding `| = "dev"` as a third alternative to each, preserving your existing bounds verbatim, if you want it as a separate PR.
- `examples/`, `tests/` and `theories/orchestrator/tests/` were not built — they need an SMT solver in the environment. The numbers above are for the `theories/` targets only.
- `theories/deciderel/` is untouched. It is not covered by any `rocq.theory` stanza (the directory has no `dune` file, and `theories/dune` has no `(include_subdirs qualified)`), so none of it is compiled; independently, `compdec_plugin.v` and `examples.v` still `Require` `MetaCoq.Template`, which has not existed since the MetaRocq rename. Repairing that is a different concern from this PR.
